### PR TITLE
fix boolean highlighting

### DIFF
--- a/Racket.tmLanguage
+++ b/Racket.tmLanguage
@@ -115,7 +115,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>[\s\(](#t|#f)[\s\)]</string>
+			<string>[\s\(\[\{](#t|#true|#f|#false)[\s\)\]\}]</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
- Highlight `#true` and `#false` as booleans
- Highlight booleans appearing within square and curly brackets (e.g. in `cond` branches)