### PR TITLE
Add 'Racket Indent.tmPreferences'

### DIFF
--- a/Racket Indent.tmPreferences
+++ b/Racket Indent.tmPreferences
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Racket Indent</string>
+    <key>scope</key>
+    <string>source.racket</string>
+    <key>settings</key>
+    <dict>
+        <key>indentSquareBrackets</key>
+        <true/>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
To enable `indentSquareBrackets`.

Without `indentSquareBrackets` set to `true`, applying `Reindent` using this syntax highlighting outputs:
```racket
(cond
  [#t
  `really-really-really-really-really-really-really-long-expression
  `really-really-really-really-really-really-really-long-expression2
  ])
```

and with `indentSquareBrackets` set to `true`, applying `Reindent` outputs (notice the 2 spaces in 3rd & 4th):
```racket
(cond
  [#t
    `really-really-really-really-really-really-really-long-expression
    `really-really-really-really-really-really-really-long-expression2
    ])
```

and also allows reindenting to the following (notice the single space in 3rd & 4th--the most readable indentation--in my opinion):
```racket
(cond
  [#t
   `really-really-really-really-really-really-really-long-expression
   `really-really-really-really-really-really-really-long-expression2
   ])
```

For people who have a "auto-reindent on save" feature setup (e.g., via [Reindent on save](https://packagecontrol.io/packages/Reindent%20on%20save) pkg), I believe this change is crucial.